### PR TITLE
fix: add browserlist defaults query

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,3 @@
-> 1%
+defaults
 iOS >= 12
 last 2 versions


### PR DESCRIPTION
### What does this PR do:

Adds `defaults` query to browserlist config.
As they [say](https://browsersl.ist/):
> Start with the default configuration
You can pick a sound set of versions with the [defaults](https://browsersl.ist/?q=defaults) query which is a shortcut for [> 0.5%, last 2 versions, Firefox ESR, not dead](https://browsersl.ist/?q=%3E%200.5%,%20last%202%20versions,%20Firefox%20ESR,%20not%20dead). It matches recent versions of popular and supported browsers worldwide and includes Firefox Extended Support Release which is updated roughly annually.

The [defaults](https://browsersl.ist/?q=defaults) query was thoroughly designed by the Browserslist community. It helps promote best practices and avoid common pitfalls.