### PR TITLE
EPMEDUTOUR-11596: Color contrast is less than 4.5:1 for text

### DIFF
--- a/src/assets/css/_variables.scss
+++ b/src/assets/css/_variables.scss
@@ -3,6 +3,6 @@ $systemFonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, 
 $color-page-bg:      #fff;
 $color-btn-bg:       #4BA83B;
 $color-btn-bg-over:  #5cb94c;
-$color-text:         #797982;
+$color-text:         #55555C;
 $color-text-head:    #1E1F20;
 

--- a/src/assets/css/components/feedbacks.scss
+++ b/src/assets/css/components/feedbacks.scss
@@ -53,7 +53,7 @@
 }
 .c-feedbacks__item-source {
     font-size: toRem(10);
-    color: #797982;
+    color: $color-text;
     letter-spacing: 2px;
     text-transform: uppercase;
 }


### PR DESCRIPTION
### What does this PR do:

Base color changed to match a11y requirements