### PR TITLE
fix: EPMEDUTOUR-15579 - The year is outdated on Radzima landing page

### DIFF
--- a/src/_components/footer.ejs
+++ b/src/_components/footer.ejs
@@ -1,7 +1,7 @@
 <footer class="footer">
     <div class="container">
         <div class="footer__copy">
-            &copy; 2022 EPAM Systems, All rights reserved
+            &copy; 2023 EPAM Systems, All rights reserved
         </div>
 
         <div class="footer__links">


### PR DESCRIPTION
### What does this PR do:
Fix year on the footer

#### Visual change - screenshot before:
![image](https://github.com/radzima-green-travel/radzima.app/assets/73526360/c0bce139-df22-4686-80e4-932283abd87b)

#### Visual change - screenshot after:
![image](https://github.com/radzima-green-travel/radzima.app/assets/73526360/e3ae8b5b-3378-4a2f-b6c4-0add42578fef)

#### Ticket Links:
https://jira.epam.com/jira/browse/EPMEDUTOUR-15579

